### PR TITLE
security: fix Dependabot alerts with scoped overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,8 +88,11 @@
       "serialize-javascript": ">=7.0.5",
       "@babel/runtime": ">=7.26.10",
       "node-forge": ">=1.4.0",
-      "brace-expansion": ">=1.1.13",
-      "picomatch": ">=2.3.2",
+      "brace-expansion@>=1.0.0 <2.0.0": ">=1.1.13",
+      "brace-expansion@>=2.0.0 <3.0.0": ">=2.0.3",
+      "brace-expansion@>=5.0.0": ">=5.0.5",
+      "picomatch@>=2.0.0 <3.0.0": ">=2.3.2",
+      "picomatch@>=4.0.0": ">=4.0.4",
       "path-to-regexp@<1.0.0": ">=0.1.13"
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,11 @@ overrides:
   serialize-javascript: '>=7.0.5'
   '@babel/runtime': '>=7.26.10'
   node-forge: '>=1.4.0'
-  brace-expansion: '>=1.1.13'
-  picomatch: '>=2.3.2'
+  brace-expansion@>=1.0.0 <2.0.0: '>=1.1.13'
+  brace-expansion@>=2.0.0 <3.0.0: '>=2.0.3'
+  brace-expansion@>=5.0.0: '>=5.0.5'
+  picomatch@>=2.0.0 <3.0.0: '>=2.3.2'
+  picomatch@>=4.0.0: '>=4.0.4'
   path-to-regexp@<1.0.0: '>=0.1.13'
 
 importers:
@@ -4590,7 +4593,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: '>=2.3.2'
+      picomatch: '>=4.0.4'
     peerDependenciesMeta:
       picomatch:
         optional: true


### PR DESCRIPTION
## Summary

Fixes the TypeDoc build failure from #92 caused by `brace-expansion` override forcing ESM-only 5.x onto `minimatch@9` which expects CJS 2.x.

- Scoped `brace-expansion` overrides per major: 1.x→≥1.1.13, 2.x→≥2.0.3, 5.x→≥5.0.5
- Scoped `picomatch` overrides: 2.x→≥2.3.2, 4.x→≥4.0.4
- Kept `serialize-javascript>=7.0.5`, `node-forge>=1.4.0`, `path-to-regexp>=0.1.13`

## Test Plan

- [x] All 54 projects build
- [x] `pnpm exec typedoc` runs successfully (was the failing step)
- [x] No vulnerable versions in lockfile