### PR TITLE
fix: remove brace-expansion overrides that broke TypeDoc build

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,10 +88,6 @@
       "serialize-javascript": ">=7.0.5",
       "@babel/runtime": ">=7.26.10",
       "node-forge": ">=1.4.0",
-      "brace-expansion@>=1.0.0 <2.0.0": ">=1.1.13",
-      "brace-expansion@>=2.0.0 <3.0.0": ">=2.0.3",
-      "brace-expansion@>=5.0.0": ">=5.0.5",
-      "picomatch@>=2.0.0 <3.0.0": ">=2.3.2",
       "picomatch@>=4.0.0": ">=4.0.4",
       "path-to-regexp@<1.0.0": ">=0.1.13"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,10 +12,6 @@ overrides:
   serialize-javascript: '>=7.0.5'
   '@babel/runtime': '>=7.26.10'
   node-forge: '>=1.4.0'
-  brace-expansion@>=1.0.0 <2.0.0: '>=1.1.13'
-  brace-expansion@>=2.0.0 <3.0.0: '>=2.0.3'
-  brace-expansion@>=5.0.0: '>=5.0.5'
-  picomatch@>=2.0.0 <3.0.0: '>=2.3.2'
   picomatch@>=4.0.0: '>=4.0.4'
   path-to-regexp@<1.0.0: '>=0.1.13'
 
@@ -3839,6 +3835,9 @@ packages:
       '@babel/traverse':
         optional: true
 
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -3885,6 +3884,12 @@ packages:
   boolean@3.2.0:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
+  brace-expansion@1.1.13:
+    resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
+
+  brace-expansion@2.0.3:
+    resolution: {integrity: sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==}
 
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
@@ -4060,6 +4065,9 @@ packages:
   compression@1.8.1:
     resolution: {integrity: sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==}
     engines: {node: '>= 0.8.0'}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   concurrently@9.2.1:
     resolution: {integrity: sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==}
@@ -5861,6 +5869,10 @@ packages:
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
 
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
@@ -10799,7 +10811,7 @@ snapshots:
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 4.0.4
+      picomatch: 2.3.2
 
   argparse@1.0.10:
     dependencies:
@@ -10920,6 +10932,8 @@ snapshots:
     optionalDependencies:
       '@babel/traverse': 7.29.0
 
+  balanced-match@1.0.2: {}
+
   balanced-match@4.0.4: {}
 
   base64-js@1.5.1: {}
@@ -10977,6 +10991,15 @@ snapshots:
 
   boolean@3.2.0:
     optional: true
+
+  brace-expansion@1.1.13:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@2.0.3:
+    dependencies:
+      balanced-match: 1.0.2
 
   brace-expansion@5.0.5:
     dependencies:
@@ -11169,6 +11192,8 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
+
+  concat-map@0.0.1: {}
 
   concurrently@9.2.1:
     dependencies:
@@ -12719,7 +12744,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 4.0.4
+      picomatch: 2.3.2
 
   mime-db@1.52.0: {}
 
@@ -12755,15 +12780,15 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 1.1.13
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 2.0.3
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 2.0.3
 
   minimist@1.2.8: {}
 
@@ -13244,6 +13269,8 @@ snapshots:
 
   picocolors@1.1.1: {}
 
+  picomatch@2.3.2: {}
+
   picomatch@4.0.4: {}
 
   pify@4.0.1:
@@ -13446,7 +13473,7 @@ snapshots:
 
   readdirp@3.6.0:
     dependencies:
-      picomatch: 4.0.4
+      picomatch: 2.3.2
 
   readdirp@4.1.2: {}
 


### PR DESCRIPTION
## Summary

Fixes the TypeDoc deploy failure caused by scoped `brace-expansion` pnpm overrides from #93.

The scoped overrides (`brace-expansion@>=1.0.0 <2.0.0`, `@>=2.0.0 <3.0.0`, `@>=5.0.0`) don't isolate in pnpm as expected — pnpm collapses all versions to the highest matching one (5.x ESM-only), breaking `minimatch@9` which needs `brace-expansion@2.x` with a CJS default export.

**Fix:** Remove `brace-expansion` and `picomatch@2.x` overrides. The lockfile refresh naturally resolves to patched versions:
- `brace-expansion`: 1.1.13, 2.0.3, 5.0.5 (all patched)
- `picomatch`: 2.3.2, 4.0.4 (all patched)

Kept: `picomatch@>=4.0.0: >=4.0.4` override (safe, single major).

## Test Plan

- [x] All 54 projects build
- [x] `pnpm exec typedoc --out typedoc-output` succeeds (was the failing CI step)
- [x] No vulnerable versions in lockfile